### PR TITLE
update-ai-plugins

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,28 @@
+name: Headless Tests
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  headless-tests:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Install Neovim
+        run: |
+          curl -LO https://github.com/neovim/neovim/releases/download/stable/nvim-linux-x86_64.tar.gz
+          sudo rm -rf /opt/nvim-linux-x86_64
+          sudo tar -C /opt -xzf nvim-linux-x86_64.tar.gz
+          sudo ln -sf /opt/nvim-linux-x86_64/bin/nvim /usr/local/bin/nvim
+
+      - name: Verify Neovim
+        run: nvim --version | sed -n '1,3p'
+
+      - name: Run Headless Tests
+        run: ./scripts/test.sh

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 tags
 test.sh
+!scripts/test.sh
 .luarc.json
 nvim
 .claude

--- a/README.md
+++ b/README.md
@@ -114,6 +114,16 @@ nvim
 That's it! Lazy will install all the plugins you have. Use `:Lazy` to view
 the current plugin status. Hit `q` to close the window.
 
+## Testing
+
+Run the headless validation suite with:
+
+```sh
+./scripts/test.sh
+```
+
+The test runner copies this config into a temporary `NVIM_APPNAME`, installs plugins into temporary XDG directories, and then boots Neovim headlessly. This catches startup regressions and broken local plugin specs without touching your normal Neovim state.
+
 #### Read The Friendly Documentation
 
 Read through the `init.lua` file in your configuration folder for more

--- a/lua/plugins_config/ai_terminal.lua
+++ b/lua/plugins_config/ai_terminal.lua
@@ -1,0 +1,13 @@
+local M = {}
+
+function M.setup(bufnr)
+  local opts = { buffer = bufnr, silent = true }
+
+  -- Leave terminal-input mode so regular window and buffer navigation works.
+  vim.keymap.set('t', '<Esc><Esc>', [[<C-\><C-n>]], vim.tbl_extend('force', opts, { desc = 'Terminal Normal Mode' }))
+
+  -- Re-enter terminal-input mode quickly after navigating around.
+  vim.keymap.set('n', 'i', function() vim.cmd 'startinsert' end, vim.tbl_extend('force', opts, { desc = 'Terminal Insert Mode' }))
+end
+
+return M

--- a/lua/plugins_config/claude.lua
+++ b/lua/plugins_config/claude.lua
@@ -4,6 +4,7 @@
 
 local claude_buf = nil
 local claude_win = nil
+local pr_draft = require 'plugins_config/pr_draft'
 
 local function is_valid()
   return claude_buf
@@ -54,3 +55,4 @@ end
 
 vim.keymap.set('n', '<leader>cct', toggle, { desc = '[C]ode [C]laude [T]oggle' })
 vim.keymap.set('v', '<leader>ccs', send_selection, { desc = '[C]ode [C]laude [S]end' })
+vim.keymap.set('n', '<leader>ccp', function() pr_draft.generate 'claude' end, { desc = '[C]ode [C]laude [P]R' })

--- a/lua/plugins_config/claude.lua
+++ b/lua/plugins_config/claude.lua
@@ -5,6 +5,7 @@
 local claude_buf = nil
 local claude_win = nil
 local pr_draft = require 'plugins_config/pr_draft'
+local explain_selection = require 'plugins_config/explain_selection'
 
 local function is_valid()
   return claude_buf
@@ -56,3 +57,4 @@ end
 vim.keymap.set('n', '<leader>cct', toggle, { desc = '[C]ode [C]laude [T]oggle' })
 vim.keymap.set('v', '<leader>ccs', send_selection, { desc = '[C]ode [C]laude [S]end' })
 vim.keymap.set('n', '<leader>ccp', function() pr_draft.generate 'claude' end, { desc = '[C]ode [C]laude [P]R' })
+vim.keymap.set('v', '<leader>cce', function() explain_selection.generate 'claude' end, { desc = '[C]ode [C]laude [E]xplain' })

--- a/lua/plugins_config/claude.lua
+++ b/lua/plugins_config/claude.lua
@@ -4,6 +4,7 @@
 
 local claude_buf = nil
 local claude_win = nil
+local ai_terminal = require 'plugins_config/ai_terminal'
 local pr_draft = require 'plugins_config/pr_draft'
 local explain_selection = require 'plugins_config/explain_selection'
 
@@ -19,6 +20,7 @@ local function open()
   vim.cmd 'terminal claude'
   claude_buf = vim.api.nvim_get_current_buf()
   claude_win = vim.api.nvim_get_current_win()
+  ai_terminal.setup(claude_buf)
   vim.cmd 'startinsert'
 end
 

--- a/lua/plugins_config/codex.lua
+++ b/lua/plugins_config/codex.lua
@@ -5,6 +5,7 @@
 local codex_buf = nil
 local codex_win = nil
 local pr_draft = require 'plugins_config/pr_draft'
+local explain_selection = require 'plugins_config/explain_selection'
 
 local function is_valid()
   return codex_buf
@@ -56,3 +57,4 @@ end
 vim.keymap.set('n', '<leader>cot', toggle, { desc = '[C]ode [O]penAI [T]oggle' })
 vim.keymap.set('v', '<leader>cos', send_selection, { desc = '[C]ode [O]penAI [S]end' })
 vim.keymap.set('n', '<leader>cop', function() pr_draft.generate 'codex' end, { desc = '[C]ode [O]penAI [P]R' })
+vim.keymap.set('v', '<leader>coe', function() explain_selection.generate 'codex' end, { desc = '[C]ode [O]penAI [E]xplain' })

--- a/lua/plugins_config/codex.lua
+++ b/lua/plugins_config/codex.lua
@@ -4,6 +4,7 @@
 
 local codex_buf = nil
 local codex_win = nil
+local ai_terminal = require 'plugins_config/ai_terminal'
 local pr_draft = require 'plugins_config/pr_draft'
 local explain_selection = require 'plugins_config/explain_selection'
 
@@ -19,6 +20,7 @@ local function open()
   vim.cmd 'terminal codex'
   codex_buf = vim.api.nvim_get_current_buf()
   codex_win = vim.api.nvim_get_current_win()
+  ai_terminal.setup(codex_buf)
   vim.cmd 'startinsert'
 end
 

--- a/lua/plugins_config/codex.lua
+++ b/lua/plugins_config/codex.lua
@@ -4,6 +4,7 @@
 
 local codex_buf = nil
 local codex_win = nil
+local pr_draft = require 'plugins_config/pr_draft'
 
 local function is_valid()
   return codex_buf
@@ -54,3 +55,4 @@ end
 
 vim.keymap.set('n', '<leader>cot', toggle, { desc = '[C]ode [O]penAI [T]oggle' })
 vim.keymap.set('v', '<leader>cos', send_selection, { desc = '[C]ode [O]penAI [S]end' })
+vim.keymap.set('n', '<leader>cop', function() pr_draft.generate 'codex' end, { desc = '[C]ode [O]penAI [P]R' })

--- a/lua/plugins_config/explain_selection.lua
+++ b/lua/plugins_config/explain_selection.lua
@@ -1,0 +1,203 @@
+-- [[ Shared code explanation helper for AI CLIs ]]
+
+local M = {}
+
+local providers = {
+  claude = {
+    cmd = function(repo_root, prompt)
+      return { 'claude', '-p', prompt, '--output-format', 'text' }
+    end,
+  },
+  codex = {
+    cmd = function(repo_root, prompt)
+      return { 'codex', 'exec', '-C', repo_root, '--skip-git-repo-check', prompt }
+    end,
+  },
+  gemini = {
+    cmd = function(repo_root, prompt)
+      return { 'gemini', '--prompt', prompt, '--output-format', 'text' }
+    end,
+  },
+}
+
+local function notify(msg, level)
+  vim.notify(msg, level or vim.log.levels.INFO, { title = 'Explain Selection' })
+end
+
+local function system(args, cwd)
+  return vim.system(args, { cwd = cwd, text = true }):wait()
+end
+
+local function git(args, cwd)
+  return system(vim.list_extend({ 'git' }, args), cwd)
+end
+
+local function trim(text)
+  return (text or ''):gsub('^%s+', ''):gsub('%s+$', '')
+end
+
+local function repo_root()
+  local result = git({ 'rev-parse', '--show-toplevel' }, vim.loop.cwd())
+  if result.code ~= 0 then
+    return nil, trim(result.stderr)
+  end
+  return trim(result.stdout), nil
+end
+
+local function get_visual_selection()
+  local start_pos = vim.fn.getpos "'<"
+  local end_pos = vim.fn.getpos "'>"
+  local lines = vim.fn.getline(start_pos[2], end_pos[2])
+
+  if #lines == 0 then
+    return nil
+  end
+
+  lines[#lines] = string.sub(lines[#lines], 1, end_pos[3])
+  lines[1] = string.sub(lines[1], start_pos[3])
+
+  return {
+    text = table.concat(lines, '\n'),
+    start_line = start_pos[2],
+    end_line = end_pos[2],
+  }
+end
+
+local function build_prompt(selection, relative_path)
+  return table.concat({
+    'Explain the following code selection.',
+    'Be concise but useful.',
+    'Focus on:',
+    '- what it does',
+    '- important control flow or data flow',
+    '- any notable risks, assumptions, or edge cases',
+    '',
+    'Return plain markdown only.',
+    'Do not ask follow-up questions.',
+    'Do not suggest next steps unless they are essential to understanding the code.',
+    '',
+    'File: ' .. relative_path,
+    'Lines: ' .. selection.start_line .. '-' .. selection.end_line,
+    '',
+    '```',
+    selection.text,
+    '```',
+  }, '\n')
+end
+
+local function show_in_telescope(title, content)
+  local pickers = require 'telescope.pickers'
+  local finders = require 'telescope.finders'
+  local previewers = require 'telescope.previewers'
+  local conf = require('telescope.config').values
+  local actions = require 'telescope.actions'
+  local action_state = require 'telescope.actions.state'
+
+  local lines = vim.split(content, '\n', { plain = true })
+
+  pickers
+    .new({}, {
+      prompt_title = title,
+      finder = finders.new_table {
+        results = {
+          {
+            value = content,
+            display = 'Explanation',
+            ordinal = 'explanation',
+          },
+        },
+      },
+      sorter = conf.generic_sorter {},
+      previewer = previewers.new_buffer_previewer {
+        title = 'Explanation',
+        define_preview = function(self, entry)
+          vim.api.nvim_buf_set_lines(self.state.bufnr, 0, -1, false, vim.split(entry.value, '\n', { plain = true }))
+          vim.bo[self.state.bufnr].filetype = 'markdown'
+          vim.bo[self.state.bufnr].modifiable = false
+          vim.bo[self.state.bufnr].readonly = true
+        end,
+      },
+      attach_mappings = function(prompt_bufnr, map)
+        local function close_picker()
+          actions.close(prompt_bufnr)
+        end
+
+        map('i', '<CR>', close_picker)
+        map('i', '<Esc>', close_picker)
+        map('n', 'q', close_picker)
+        map('n', '<Esc>', close_picker)
+        map('n', '<CR>', close_picker)
+
+        actions.select_default:replace(function()
+          local _ = action_state.get_selected_entry()
+          actions.close(prompt_bufnr)
+        end)
+
+        return true
+      end,
+    })
+    :find()
+
+  if #lines == 0 then
+    notify('Explanation was empty', vim.log.levels.WARN)
+  end
+end
+
+function M.generate(provider_name)
+  local provider = providers[provider_name]
+  if not provider then
+    notify('Unsupported provider: ' .. provider_name, vim.log.levels.ERROR)
+    return
+  end
+
+  if vim.fn.executable(provider_name) ~= 1 then
+    notify(provider_name .. ' is not installed or not on PATH', vim.log.levels.ERROR)
+    return
+  end
+
+  local selection = get_visual_selection()
+  if not selection or trim(selection.text) == '' then
+    notify('No visual selection found', vim.log.levels.ERROR)
+    return
+  end
+
+  local root, root_err = repo_root()
+  if not root then
+    notify('Not inside a git repository: ' .. root_err, vim.log.levels.ERROR)
+    return
+  end
+
+  local file_path = vim.api.nvim_buf_get_name(0)
+  local relative_path = vim.fn.fnamemodify(file_path, ':.')
+  if relative_path == '' then
+    relative_path = '[No Name]'
+  end
+
+  local prompt = build_prompt(selection, relative_path)
+  local cmd = provider.cmd(root, prompt)
+
+  notify('Generating explanation with ' .. provider_name .. '...')
+
+  vim.system(cmd, { cwd = root, text = true }, function(result)
+    vim.schedule(function()
+      if result.code ~= 0 then
+        local err = trim(result.stderr)
+        if err == '' then
+          err = 'provider exited with code ' .. result.code
+        end
+        notify(provider_name .. ' failed: ' .. err, vim.log.levels.ERROR)
+        return
+      end
+
+      local explanation = trim(result.stdout)
+      if explanation == '' then
+        notify(provider_name .. ' returned an empty explanation', vim.log.levels.ERROR)
+        return
+      end
+
+      show_in_telescope('Explain ' .. relative_path, explanation)
+    end)
+  end)
+end
+
+return M

--- a/lua/plugins_config/gemini.lua
+++ b/lua/plugins_config/gemini.lua
@@ -5,6 +5,7 @@
 local gemini_buf = nil
 local gemini_win = nil
 local pr_draft = require 'plugins_config/pr_draft'
+local explain_selection = require 'plugins_config/explain_selection'
 
 local function is_valid()
   return gemini_buf
@@ -51,3 +52,4 @@ end
 vim.keymap.set('n', '<leader>cgt', toggle, { desc = '[C]ode [G]emini [T]oggle' })
 vim.keymap.set('v', '<leader>cgs', send_selection, { desc = '[C]ode [G]emini [S]end' })
 vim.keymap.set('n', '<leader>cgp', function() pr_draft.generate 'gemini' end, { desc = '[C]ode [G]emini [P]R' })
+vim.keymap.set('v', '<leader>cge', function() explain_selection.generate 'gemini' end, { desc = '[C]ode [G]emini [E]xplain' })

--- a/lua/plugins_config/gemini.lua
+++ b/lua/plugins_config/gemini.lua
@@ -4,6 +4,7 @@
 
 local gemini_buf = nil
 local gemini_win = nil
+local pr_draft = require 'plugins_config/pr_draft'
 
 local function is_valid()
   return gemini_buf
@@ -49,3 +50,4 @@ end
 
 vim.keymap.set('n', '<leader>cgt', toggle, { desc = '[C]ode [G]emini [T]oggle' })
 vim.keymap.set('v', '<leader>cgs', send_selection, { desc = '[C]ode [G]emini [S]end' })
+vim.keymap.set('n', '<leader>cgp', function() pr_draft.generate 'gemini' end, { desc = '[C]ode [G]emini [P]R' })

--- a/lua/plugins_config/gemini.lua
+++ b/lua/plugins_config/gemini.lua
@@ -4,6 +4,7 @@
 
 local gemini_buf = nil
 local gemini_win = nil
+local ai_terminal = require 'plugins_config/ai_terminal'
 local pr_draft = require 'plugins_config/pr_draft'
 local explain_selection = require 'plugins_config/explain_selection'
 
@@ -19,6 +20,7 @@ local function open()
   vim.cmd 'terminal gemini'
   gemini_buf = vim.api.nvim_get_current_buf()
   gemini_win = vim.api.nvim_get_current_win()
+  ai_terminal.setup(gemini_buf)
   vim.cmd 'startinsert'
 end
 

--- a/lua/plugins_config/lint.lua
+++ b/lua/plugins_config/lint.lua
@@ -6,6 +6,7 @@ return {
     config = function()
       local lint = require 'lint'
       lint.linters_by_ft = {
+        lua = { 'luacheck' },
         markdown = { 'markdownlint' },
       }
 

--- a/lua/plugins_config/lsp.lua
+++ b/lua/plugins_config/lsp.lua
@@ -282,6 +282,10 @@ return {
       -- for you, so that they are available from within Neovim.
       local ensure_installed = vim.tbl_keys(servers or {})
       vim.list_extend(ensure_installed, {
+        'ansible-lint',
+        'yamllint',
+        'terraform',
+        'staticcheck',
         'rustfmt', -- Rust formatter
         'prettier', -- JS/MD formatter
         'shellcheck',
@@ -328,7 +332,6 @@ return {
     'nvimtools/none-ls.nvim',
     dependencies = {
       'nvim-lua/plenary.nvim',
-      'nvimtools/none-ls-extras.nvim', -- provides shellcheck, ruff (removed from core none-ls)
     },
     config = function()
       local null_ls = require 'null-ls'
@@ -348,8 +351,6 @@ return {
           -- require("none-ls.diagnostics.ruff"),
           -- Go (staticcheck)
           null_ls.builtins.diagnostics.staticcheck,
-          -- Lua
-          null_ls.builtins.diagnostics.luacheck,
           -- Markdown
           null_ls.builtins.diagnostics.markdownlint,
         },

--- a/lua/plugins_config/pr_draft.lua
+++ b/lua/plugins_config/pr_draft.lua
@@ -1,0 +1,141 @@
+-- [[ Shared PR draft helper for AI CLIs ]]
+
+local M = {}
+
+local tmpfile = '/tmp/pr-draft.md'
+
+local providers = {
+  claude = {
+    cmd = function(repo_root, prompt)
+      return { 'claude', '-p', prompt, '--output-format', 'text' }
+    end,
+  },
+  codex = {
+    cmd = function(repo_root, prompt)
+      return { 'codex', 'exec', '-C', repo_root, '--skip-git-repo-check', prompt }
+    end,
+  },
+  gemini = {
+    cmd = function(repo_root, prompt)
+      return { 'gemini', '--prompt', prompt, '--output-format', 'text' }
+    end,
+  },
+}
+
+local function notify(msg, level)
+  vim.notify(msg, level or vim.log.levels.INFO, { title = 'PR Draft' })
+end
+
+local function system(args, cwd)
+  local result = vim.system(args, { cwd = cwd, text = true }):wait()
+  return result
+end
+
+local function git(args, cwd)
+  return system(vim.list_extend({ 'git' }, args), cwd)
+end
+
+local function trim(text)
+  return (text or ''):gsub('^%s+', ''):gsub('%s+$', '')
+end
+
+local function repo_root()
+  local result = git({ 'rev-parse', '--show-toplevel' }, vim.loop.cwd())
+  if result.code ~= 0 then
+    return nil, trim(result.stderr)
+  end
+  return trim(result.stdout), nil
+end
+
+local function branch_name(cwd)
+  local result = git({ 'rev-parse', '--abbrev-ref', 'HEAD' }, cwd)
+  if result.code ~= 0 then
+    return nil, trim(result.stderr)
+  end
+  return trim(result.stdout), nil
+end
+
+local function build_prompt(branch)
+  return table.concat({
+    'Draft the body for a GitHub pull request for the current repository.',
+    'Inspect the current branch diff, staged and unstaged changes, and recent commits yourself.',
+    'The PR title is fixed and must be exactly this branch name: ' .. branch .. '.',
+    'Return markdown for the PR body only.',
+    'Keep it concise and accurate.',
+    'Use exactly these sections:',
+    '## Summary',
+    '- ...',
+    '',
+    '## Testing',
+    '- ...',
+  }, '\n')
+end
+
+local function write_draft(branch, body)
+  local lines = {
+    branch,
+    '',
+  }
+
+  vim.list_extend(lines, vim.split(trim(body), '\n', { plain = true }))
+  vim.fn.writefile(lines, tmpfile)
+end
+
+local function open_draft()
+  vim.cmd('edit ' .. vim.fn.fnameescape(tmpfile))
+end
+
+function M.generate(provider_name)
+  local provider = providers[provider_name]
+  if not provider then
+    notify('Unsupported provider: ' .. provider_name, vim.log.levels.ERROR)
+    return
+  end
+
+  if vim.fn.executable(provider_name) ~= 1 then
+    notify(provider_name .. ' is not installed or not on PATH', vim.log.levels.ERROR)
+    return
+  end
+
+  local root, root_err = repo_root()
+  if not root then
+    notify('Not inside a git repository: ' .. root_err, vim.log.levels.ERROR)
+    return
+  end
+
+  local branch, branch_err = branch_name(root)
+  if not branch then
+    notify('Unable to resolve branch name: ' .. branch_err, vim.log.levels.ERROR)
+    return
+  end
+
+  local prompt = build_prompt(branch)
+  local cmd = provider.cmd(root, prompt)
+
+  notify('Generating PR draft with ' .. provider_name .. '...')
+
+  vim.system(cmd, { cwd = root, text = true }, function(result)
+    vim.schedule(function()
+      if result.code ~= 0 then
+        local err = trim(result.stderr)
+        if err == '' then
+          err = 'provider exited with code ' .. result.code
+        end
+        notify(provider_name .. ' failed: ' .. err, vim.log.levels.ERROR)
+        return
+      end
+
+      local body = trim(result.stdout)
+      if body == '' then
+        notify(provider_name .. ' returned an empty PR body', vim.log.levels.ERROR)
+        return
+      end
+
+      write_draft(branch, body)
+      open_draft()
+      notify('PR draft written to ' .. tmpfile)
+    end)
+  end)
+end
+
+return M

--- a/lua/tests/runner.lua
+++ b/lua/tests/runner.lua
@@ -1,0 +1,120 @@
+local M = {}
+
+local coreModules = {
+  'options',
+  'keymaps',
+  'autocommands',
+  'plugins_config/pr_draft',
+  'plugins_config/explain_selection',
+  'plugins_config/claude',
+  'plugins_config/codex',
+  'plugins_config/gemini',
+}
+
+local pluginSpecModules = {
+  'plugins_config/autocomplete',
+  'plugins_config/code_runner',
+  'plugins_config/colortheme',
+  'plugins_config/conform',
+  'plugins_config/gitsigns',
+  'plugins_config/harpoon',
+  'plugins_config/indent_line',
+  'plugins_config/lint',
+  'plugins_config/lsp',
+  'plugins_config/mini',
+  'plugins_config/telescope',
+  'plugins_config/tree-sitter',
+  'plugins_config/vim-fugitive',
+  'plugins_config/which-key',
+  'plugins_config/worktree',
+}
+
+local function pushFailure(failures, message)
+  failures[#failures + 1] = message
+end
+
+local function expect(failures, condition, message)
+  if not condition then
+    pushFailure(failures, message)
+  end
+end
+
+local function safeRequire(failures, moduleName)
+  local ok, result = pcall(require, moduleName)
+  if not ok then
+    pushFailure(failures, string.format("require('%s') failed: %s", moduleName, result))
+    return nil
+  end
+  return result
+end
+
+local function isPluginTarget(spec)
+  return (type(spec[1]) == 'string' and spec[1] ~= '') or (type(spec.import) == 'string' and spec.import ~= '')
+end
+
+local function isPluginSpecList(spec)
+  return type(spec[1]) == 'table'
+end
+
+local function validatePluginSpec(failures, moduleName)
+  local spec = safeRequire(failures, moduleName)
+  if type(spec) ~= 'table' then
+    pushFailure(failures, string.format("module '%s' did not return a table plugin spec", moduleName))
+    return
+  end
+
+  if isPluginTarget(spec) then
+    return
+  end
+
+  if isPluginSpecList(spec) then
+    expect(failures, #spec > 0, string.format("plugin spec list '%s' is empty", moduleName))
+    for index, childSpec in ipairs(spec) do
+      expect(
+        failures,
+        type(childSpec) == 'table' and isPluginTarget(childSpec),
+        string.format("plugin spec list '%s' has an invalid entry at index %d", moduleName, index)
+      )
+    end
+    return
+  end
+
+  pushFailure(failures, string.format("plugin spec '%s' is missing a repository or import target", moduleName))
+end
+
+function M.run()
+  local failures = {}
+
+  expect(failures, vim.g.mapleader == ' ', 'mapleader was not initialized to <space>')
+
+  local lazyConfig = safeRequire(failures, 'lazy.core.config')
+  if lazyConfig then
+    expect(failures, type(lazyConfig.plugins) == 'table' and next(lazyConfig.plugins) ~= nil, 'lazy did not register any plugins')
+  end
+
+  for _, moduleName in ipairs(coreModules) do
+    safeRequire(failures, moduleName)
+  end
+
+  local health = safeRequire(failures, 'plugins_config/health')
+  if health then
+    expect(failures, type(health.check) == 'function', "health module does not expose a 'check' function")
+  end
+
+  for _, moduleName in ipairs(pluginSpecModules) do
+    validatePluginSpec(failures, moduleName)
+  end
+
+  if #failures > 0 then
+    vim.api.nvim_err_writeln('Test failures:')
+    for _, failure in ipairs(failures) do
+      vim.api.nvim_err_writeln('- ' .. failure)
+    end
+    vim.cmd('cquit ' .. #failures)
+    return
+  end
+
+  print(string.format('All tests passed (%d core modules, %d plugin specs)', #coreModules, #pluginSpecModules))
+end
+
+return M

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+tmp_dir="$(mktemp -d)"
+app_name="nvim-test"
+
+cleanup() {
+  rm -rf "$tmp_dir"
+}
+
+trap cleanup EXIT
+
+mkdir -p "$tmp_dir/config/$app_name" "$tmp_dir/data" "$tmp_dir/state" "$tmp_dir/cache"
+cp -R "$repo_root"/. "$tmp_dir/config/$app_name"
+
+export NVIM_APPNAME="$app_name"
+export XDG_CONFIG_HOME="$tmp_dir/config"
+export XDG_DATA_HOME="$tmp_dir/data"
+export XDG_STATE_HOME="$tmp_dir/state"
+export XDG_CACHE_HOME="$tmp_dir/cache"
+
+cd "$tmp_dir/config/$app_name"
+
+nvim --headless \
+  "+Lazy! sync" \
+  "+lua require('tests.runner').run()" \
+  +qa


### PR DESCRIPTION
## Summary
- Add shared AI terminal integration plus new PR-draft and visual-selection explanation helpers for the Claude, Codex, and Gemini Neovim commands.
- Add a headless Neovim test runner, GitHub Actions coverage, and README instructions for running the validation flow locally.
- Expand lint/tooling setup by enabling `luacheck` linting and updating installed formatter/linter dependencies in the LSP config.

## Testing
- Not run locally for this draft.
- Added `./scripts/test.sh` and `.github/workflows/tests.yml` to run the headless validation suite in CI.
